### PR TITLE
서비스 페이지에서의 API 최적화

### DIFF
--- a/pages/api/[id].ts
+++ b/pages/api/[id].ts
@@ -1,7 +1,7 @@
 import template from '../../utils/template';
 import { countPosts, getUser } from '../../utils/crawling';
 
-const defaultBadgeController = async (req, res) => {
+const DefaultBadgeController = async (req, res) => {
   const { id } = req.query;
   const user = await getUser(id);
   if (!user) {
@@ -12,4 +12,4 @@ const defaultBadgeController = async (req, res) => {
   res.status(200).send(template(user.name, user.role, posts));
 };
 
-export default defaultBadgeController;
+export default DefaultBadgeController;

--- a/pages/api/all/[id].ts
+++ b/pages/api/all/[id].ts
@@ -1,0 +1,22 @@
+import { countPosts, getUser } from '../../../utils/crawling';
+import colorTemplate from '../../../utils/colorTemplate';
+import template from '../../../utils/template';
+
+const AllBadgeController = async (req, res) => {
+  const { id } = req.query;
+  const user = await getUser(id);
+  if (!user) {
+    return res.status(204).send();
+  }
+  const posts = await countPosts(user);
+  res.setHeader('Content-type', 'image/svg+xml');
+
+  const badges = {
+    default: template(user.github, user.role, posts),
+    color: colorTemplate(user.github, user.role, posts),
+  };
+
+  res.status(200).json(badges);
+};
+
+export default AllBadgeController;

--- a/pages/api/color/[id].ts
+++ b/pages/api/color/[id].ts
@@ -1,7 +1,7 @@
 import colorTemplate from '../../../utils/colorTemplate';
 import { countPosts, getUser } from '../../../utils/crawling';
 
-const colorBadgeController = async (req, res) => {
+const ColorBadgeController = async (req, res) => {
   const { id } = req.query;
   const user = await getUser(id);
   if (!user) {
@@ -12,4 +12,4 @@ const colorBadgeController = async (req, res) => {
   res.status(200).send(colorTemplate(user.github, user.role, posts));
 };
 
-export default colorBadgeController;
+export default ColorBadgeController;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -93,15 +93,16 @@ const Index = () => {
   };
   const generateSVG = async () => {
     setIsLoading(true);
-    const basicBadgeRes = await axios.get(`/api/${githubID}`);
-    const colorBadgeRes = await axios.get(`/api/color/${githubID}`);
-    if (basicBadgeRes.status === 200) {
-      setSVG(basicBadgeRes.data);
-      setColorSVG(colorBadgeRes.data);
-      setSuccess(true);
-    } else if (basicBadgeRes.status === 204) {
+    const res = await axios.get(`/api/all/${githubID}`);
+    if (res.status === 204) {
       alert('데이터 찾을 수 없음');
       setSuccess(false);
+    }
+    if (res.status === 200) {
+      const badgeList = await res.data;
+      setSVG(badgeList.default);
+      setColorSVG(badgeList.color);
+      setSuccess(true);
     }
     setIsLoading(false);
   };


### PR DESCRIPTION
## 작업 내용
- [x] Controller 이름 PascalCase로 변경
- [x] `/api/all/[id]` 작성

## 전달 사항
**api 자체 속도를 빠르게 한 것은 아닙니다!**
현재 서비스 페이지는 쉽게 개발하고자 뱃지 각각 api 호출해서 보여줬었는데, 이러면 같은 유저 데이터에 대해 크롤링을 두 번 해야 하는 문제가 있었습니다.

처음에는 페이지에서 직접 크롤링 함수랑 template을 반환할 수 있도록 바꿨는데, `next`에서 다른 곳에 있는 파일을 접근 못하게 하더라구요 😅

그래서 새로운 API를 작성해서 해결했습니다.

아래 제 로컬 환경에서 구동시킨 스크린샷을 보시면, api 호출 시간만 비교했을 때 기존 `6.64s + 2.71s = 9.35s`에서 `4.42s`까지 단축된 것을 확인할 수 있습니다. 내부적으로 캐싱이 적용됐나 싶다고 생각될 만큼 단축된 결과라 정확하지 않은 것 같습니다 😓

## 스크린샷
![image](https://user-images.githubusercontent.com/42960217/158806022-947d2d95-df8d-40e4-8e9f-b18befef6af0.png)
![image](https://user-images.githubusercontent.com/42960217/158806179-954c01f1-68a5-4ede-8e0b-a7d13ea4aff6.png)
